### PR TITLE
Add sequence type check when using `unordered` with single argument

### DIFF
--- a/pytest_unordered.py
+++ b/pytest_unordered.py
@@ -28,7 +28,7 @@ class UnorderedList(list):
         return not extra_left and not extra_right
 
     def __ne__(self, actual: Iterable) -> bool:
-        return not self.__eq__(actual)
+        return not (self == actual)
 
 
 def unordered(*args) -> UnorderedList:

--- a/pytest_unordered.py
+++ b/pytest_unordered.py
@@ -16,7 +16,7 @@ class UnorderedList(list):
         self._expected_type = type(expected) if check_type else None
 
     def __eq__(self, actual: Iterable) -> bool:
-        if self._expected_type and self._expected_type != type(actual):
+        if self._expected_type is not None and self._expected_type != type(actual):
             return False
         if not isinstance(actual, Iterable):
             return self.copy() == actual
@@ -58,7 +58,7 @@ def pytest_assertrepr_compare(config, op, left, right):
         right_type = right._expected_type if isinstance(right, UnorderedList) else type(right)
         if left_type and right_type and left_type != right_type:
             result.append("Type mismatch:")
-            result.append("{l} != {r}".format(l=left_type, r=right_type))
+            result.append("{} != {}".format(left_type, right_type))
         extra_left, extra_right = _compare_eq_unordered(left, right)
         if len(extra_left) == 1 and len(extra_right) == 1:
             result.append("One item replaced:")

--- a/pytest_unordered.py
+++ b/pytest_unordered.py
@@ -1,5 +1,5 @@
 from typing import Generator
-from typing import Iterable
+from typing import Iterable, Mapping
 from typing import Sized
 
 from _pytest._io.saferepr import saferepr
@@ -11,6 +11,10 @@ class UnorderedList(list):
         if not isinstance(expected, Iterable):
             raise TypeError(
                 "cannot make unordered comparisons to non-iterable: {!r}".format(expected)
+            )
+        if isinstance(expected, Mapping):
+            raise TypeError(
+                "cannot make unordered comparisons to mapping: {!r}".format(expected)
             )
         super().__init__(expected)
         self._expected_type = type(expected) if check_type else None

--- a/tests/test_unordered.py
+++ b/tests/test_unordered.py
@@ -7,18 +7,83 @@ from pytest_unordered import unordered
 
 
 @pytest.mark.parametrize(
-    "left,right",
+    ["expected", "actual"],
     [
         (unordered(1, 2, 3), [3, 2, 1]),
-        ([3, 2, 1], unordered(1, 2, 3)),
+        (unordered(1, 2, 3), (3, 2, 1)),
+        (unordered(1, 2, 3), {3, 2, 1}),
+        (unordered([1, 2, 3]), [3, 2, 1]),
+        (unordered((1, 2, 3)), (3, 2, 1)),
+        (unordered({1, 2, 3}), {3, 2, 1}),
+        (unordered({1: 2, 3: 4}), {3: 4, 1: 2}),
         (unordered(1, 2, {"a": unordered(4, 5, 6)}), [{"a": [6, 5, 4]}, 2, 1]),
-        ([3, 2, {1: ['b', 'a']}], unordered({1: unordered('a', 'b')}, 2, 3)),
+        (unordered([{1: unordered(['a', 'b'])}, 2, 3]), [3, 2, {1: ['b', 'a']}]),
         (unordered(x for x in range(3)), [2, 1, 0]),
-        ((x for x in range(3)), unordered(2, 1, 0)),
+        (unordered(x for x in range(3)), (2, 1, 0)),
+        (unordered(x for x in range(3)), {2, 1, 0}),
+        (unordered(x for x in range(3)), range(3)),
+        (unordered("abc"), "bac"),
+        (unordered("a", "b", "c"), ["b", "a", "c"]),
+        (unordered("a", "b", "c"), "bac"),
     ],
 )
-def test_unordered(left, right):
+def test_unordered(expected, actual):
+    assert expected == actual
+    assert actual == expected
+    with pytest.raises(AssertionError):
+        assert expected != actual
+    with pytest.raises(AssertionError):
+        assert actual != expected
+
+
+@pytest.mark.parametrize(
+    ["left", "right"],
+    [
+        (unordered(2, 1, 0), (x for x in range(3))),
+        ((x for x in range(3)), unordered(2, 1, 0)),
+        (unordered(x for x in range(3)), (2, 1, 0),),
+        ((2, 1, 0), unordered(x for x in range(3))),
+        (unordered("a", "b", "c"), (x for x in "bac")),
+        ((x for x in "bac"), unordered("a", "b", "c")),
+    ]
+)
+def test_unordered_generators(left, right):
+    # Because general generators can only be consumed once,
+    # we can only do one assert
     assert left == right
+
+
+@pytest.mark.parametrize(
+    ["expected", "actual"],
+    [
+        (unordered([1, 2, 3]), [1, 2, 3, 4]),
+        (unordered([1, 2, 3]), [1, 2, 3, 1]),
+        (unordered([1, 2, 3]), (1, 2, 3)),
+        (unordered([1, 2, 3]), {1, 2, 3}),
+        (unordered([1, 2, 3]), (x + 1 for x in range(3))),
+        (unordered((1, 2, 3)), (1, 2, 3, 4)),
+        (unordered((1, 2, 3)), (1, 2, 3, 1)),
+        (unordered((1, 2, 3)), [1, 2, 3]),
+        (unordered((1, 2, 3)), {1, 2, 3}),
+        (unordered((1, 2, 3)), (x + 1 for x in range(3))),
+        (unordered({1, 2, 3}), {1, 2, 3, 4}),
+        (unordered({1, 2, 3}), [1, 2, 3]),
+        (unordered({1, 2, 3}), (1, 2, 3)),
+        (unordered({1, 2, 3}), (x + 1 for x in range(3))),
+        (unordered("abc"), ["b", "a", "c"]),
+        (unordered("abc"), ("b", "a", "c")),
+        (unordered("abc"), {"b", "a", "c"}),
+    ],
+)
+def test_unordered_reject(expected, actual):
+    assert not expected == actual
+    assert expected != actual
+    assert not actual == expected
+    assert actual != expected
+    with raises(AssertionError):
+        assert expected == actual
+    with raises(AssertionError):
+        assert actual == expected
 
 
 @pytest.mark.parametrize("value", [None, type, TypeError])
@@ -118,4 +183,21 @@ def test_in(testdir):
     result.stdout.fnmatch_lines([
         "E       assert 1 in [2, 3]",
         "E        +  where [2, 3] = unordered(2, 3)",
+    ])
+
+
+def test_type_check(testdir):
+    testdir.makepyfile(
+        """
+        from pytest_unordered import unordered
+
+        def test_unordered():
+            assert [3, 2, 1] == unordered((1, 2, 3))
+        """
+    )
+    result = testdir.runpytest()
+    result.assert_outcomes(failed=1, passed=0)
+    result.stdout.fnmatch_lines([
+        "E         Type mismatch:",
+        "E         <class 'list'> != <class 'tuple'>",
     ])

--- a/tests/test_unordered.py
+++ b/tests/test_unordered.py
@@ -30,10 +30,8 @@ from pytest_unordered import unordered
 def test_unordered(expected, actual):
     assert expected == actual
     assert actual == expected
-    with pytest.raises(AssertionError):
-        assert expected != actual
-    with pytest.raises(AssertionError):
-        assert actual != expected
+    assert not (expected != actual)
+    assert not (actual != expected)
 
 
 @pytest.mark.parametrize(
@@ -76,14 +74,10 @@ def test_unordered_generators(left, right):
     ],
 )
 def test_unordered_reject(expected, actual):
-    assert not expected == actual
     assert expected != actual
-    assert not actual == expected
     assert actual != expected
-    with raises(AssertionError):
-        assert expected == actual
-    with raises(AssertionError):
-        assert actual == expected
+    assert not (expected == actual)
+    assert not (actual == expected)
 
 
 @pytest.mark.parametrize("value", [None, type, TypeError])


### PR DESCRIPTION
Addresses #2 
