### PR TITLE
Add `check_type` argument to make it possible to disable type checking for single non-generator positional argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.1] - 2021-02-06
+## [0.4.1] - 2021-03-28
 - Add `check_type` argument to make it possible to disable type checking for single non-generators positional argument
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.1] - 2021-02-06
+- Add `check_type` argument to make it possible to disable type checking for single non-generators positional argument
+
+
 ## [0.4.0] - 2020-11-02
 - Add sequence type check when using `unordered` with single argument
 

--- a/pytest_unordered.py
+++ b/pytest_unordered.py
@@ -1,5 +1,6 @@
 from typing import Generator
 from typing import Iterable, Mapping
+from typing import Optional
 from typing import Sized
 
 from _pytest._io.saferepr import saferepr
@@ -35,9 +36,11 @@ class UnorderedList(list):
         return not (self == actual)
 
 
-def unordered(*args) -> UnorderedList:
+def unordered(*args, check_type: Optional[bool] = None) -> UnorderedList:
     if len(args) == 1:
-        return UnorderedList(args[0], check_type=not isinstance(args[0], Generator))
+        if check_type is None:
+            check_type = not isinstance(args[0], Generator)
+        return UnorderedList(args[0], check_type=check_type)
     return UnorderedList(args, check_type=False)
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="pytest-unordered",
-    version="0.4.0",
+    version="0.4.1",
     author="Ivan Zaikin",
     author_email="ut@pyngo.tom.ru",
     maintainer="Ivan Zaikin",

--- a/tests/test_unordered.py
+++ b/tests/test_unordered.py
@@ -110,6 +110,12 @@ def test_compare_to_non_sequence(value):
     assert unordered("x") != value
 
 
+def test_check_type():
+    assert not unordered([1]) == {1}
+    assert not unordered([1], check_type=True) == {1}
+    assert unordered([1], check_type=False) == {1}
+
+
 @pytest.mark.parametrize(
     "left,right,extra_left,extra_right",
     [


### PR DESCRIPTION
Resolves #5