### PR TITLE
remove usage of old external "mock" module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: python -m pip install mypy types-mock types-setuptools .
+      run: python -m pip install mypy types-setuptools .
     - name: mypy
       run: mypy .
 
@@ -70,7 +70,7 @@ jobs:
       with:
         python-version: "${{ matrix.python-version }}"
     - name: Install dependencies
-      run: python -m pip install mock tox "${{ matrix.pytest-version }}" pytest-cov .
+      run: python -m pip install tox "${{ matrix.pytest-version }}" pytest-cov .
     - name: Test
       run: |
         coverage run --branch --source=pytest_unordered -m pytest tests/

--- a/tests/test_unordered.py
+++ b/tests/test_unordered.py
@@ -3,12 +3,12 @@ from typing import Any
 from typing import Iterable
 from typing import List
 from typing import Mapping
+from unittest.mock import ANY
 
 import pytest
 from _pytest.pytester import Pytester
 from pytest import raises
 
-from mock import ANY
 from pytest_unordered import UnorderedList
 from pytest_unordered import _compare_eq_unordered
 from pytest_unordered import unordered

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ commands =
 deps =
   coverage
   codecov
-  mock
   pytest7: pytest==7.4.4
   pytest8: pytest==8.1.1
   pytestlatest: pytest
@@ -27,7 +26,6 @@ commands = mypy .
 deps =
   mypy
   pytest
-  types-mock
   types-setuptools
 
 [flake8]


### PR DESCRIPTION
Dear Maintainer,

mock has now been merged in the standard library a long time ago,
please consider removing this old external dependency

----

https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.