### PR TITLE
Reapply "Add Python 3.13 support"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## [0.6.1] - 2024-07-05
 - Fix matching with `mock.ANY` (#16)
+- Add Python 3.13 support
 
 
 ## [0.6.0] - 2024-03-13

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Testing",


### PR DESCRIPTION
This was already done in 27195d but then reverted in 05504d presumably because the GH Action was unsuccessful.

Python 3.13 is now available in the Ubuntu base image, so the GH Action goes through just fine.

This just re-applies 05504d.

I ran it on my fork here, if you want to take a look first: https://github.com/arminfriedl/pytest-unordered/actions/runs/15365236972

I'd also really appreciate a new 0.6.2 release :)