### PR TITLE
Fix API breakage with pytest 9.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         pytest-version:
           - "pytest<8"
           - "pytest<9"
+          - "pytest<10"
           - "pytest"
           - "git+https://github.com/pytest-dev/pytest.git@main"
         exclude:

--- a/pytest_unordered/__init__.py
+++ b/pytest_unordered/__init__.py
@@ -114,12 +114,16 @@ def pytest_assertrepr_compare(
                     _compare_eq_any(extra_left[0], extra_right[0], verbose=verbose),  # type: ignore[call-arg]
                 )
             else:
+                args = {}
+                if pytest.version_tuple >= (9, 1, 0):
+                    args = {"assertion_text_diff_style": "ndiff"}
                 result.extend(
                     _compare_eq_any(
                         extra_left[0],
                         extra_right[0],
                         highlighter=config.get_terminal_writer()._highlight,  # noqa: SLF001
                         verbose=verbose,
+                        **args,
                     ),
                 )
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py38,py39}-{pytest7,pytest8},
-    {py310,py311,py312,py313,pypy3}-{pytest7,pytest8,pytestlatest},
+    {py310,py311,py312,py313,pypy3}-{pytest7,pytest8,pytest9,pytestlatest},
     prek
 
 [testenv]
@@ -12,6 +12,7 @@ deps =
   codecov
   pytest7: pytest>=7.4.4,<8
   pytest8: pytest>=8.1.1,<9
+  pytest9: pytest>=9.1,<10
   pytestlatest: pytest
 
 [testenv:prek]


### PR DESCRIPTION
The ndiff value matches the previous default.

https://github.com/pytest-dev/pytest/commit/58d8b55beb7b341fb7d8a90a0a0bce1e701fb280

```pytb
________________________________ test_unordered ________________________________

    def test_unordered():
>       assert [{"a": 1, "b": 2}, 2, 3] == unordered(2, 3, {"b": 2, "a": 3})

test_replace.py:4: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/hminjv65d9b6di6l0ivxj92wrbcdhym3-python3.14-pytest-9.1.0/lib/python3.14/site-packages/_pytest/assertion/rewrite.py:498: in _call_reprcompare
    custom = util._reprcompare(ops[i], each_obj[i], each_obj[i + 1])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/hminjv65d9b6di6l0ivxj92wrbcdhym3-python3.14-pytest-9.1.0/lib/python3.14/site-packages/_pytest/assertion/__init__.py:180: in callbinrepr
    hook_result = ihook.pytest_assertrepr_compare(
/nix/store/483a909gxsl0wzbyp9dfrb2ksi42r7i6-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/483a909gxsl0wzbyp9dfrb2ksi42r7i6-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/483a909gxsl0wzbyp9dfrb2ksi42r7i6-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py:475: in traced_hookexec
    return outcome.get_result()
           ^^^^^^^^^^^^^^^^^^^^
/nix/store/483a909gxsl0wzbyp9dfrb2ksi42r7i6-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py:472: in <lambda>
    lambda: oldcall(hook_name, hook_impls, caller_kwargs, firstresult)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

config = <_pytest.config.Config object at 0x7ffff54a9a90>, op = '=='
left = [{'a': 1, 'b': 2}, 2, 3], right = [{'b': 2, 'a': 3}, 2, 3]

    def pytest_assertrepr_compare(
        config: Config,
        op: str,
        left: Any,
        right: Any,
    ) -> list[str] | None:
        if (isinstance(left, UnorderedList) or isinstance(right, UnorderedList)) and op == "==":
            verbose = config.getoption("verbose")
            left_repr = saferepr(left)
            right_repr = saferepr(right)
            result = [f"{left_repr} {op} {right_repr}"]
            left_type = left.expected_type if isinstance(left, UnorderedList) else type(left)
            right_type = right.expected_type if isinstance(right, UnorderedList) else type(right)
            if left_type and right_type and left_type != right_type:
                result.append("Type mismatch:")
                result.append(f"{left_type} != {right_type}")
            extra_left, extra_right = _compare_eq_unordered(left, right)
            if len(extra_left) == 1 and len(extra_right) == 1:
                result.append("One item replaced:")
                if pytest.version_tuple < (8, 0, 0):  # pragma: no cover
                    result.extend(
                        _compare_eq_any(extra_left[0], extra_right[0], verbose=verbose),  # type: ignore[call-arg]
                    )
                else:
                    result.extend(
>                       _compare_eq_any(
                            extra_left[0],
                            extra_right[0],
                            highlighter=config.get_terminal_writer()._highlight,  # noqa: SLF001
                            verbose=verbose,
                        ),
                    )
E                   TypeError: _compare_eq_any() missing 1 required positional argument: 'assertion_text_diff_style'

/build/source/pytest_unordered/__init__.py:118: TypeError
```